### PR TITLE
fix --max-players

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use asa_wrap::{GameUserSettings, IniFile, MAX_PLAYERS, SERVER_ADMIN_PASSWORD, SERVER_PASSWORD};
+use asa_wrap::{GameUserSettings, IniFile, SERVER_ADMIN_PASSWORD, SERVER_PASSWORD};
 use clap::Parser;
 use env_logger::init;
 use ini::ini;
@@ -66,6 +66,14 @@ impl Args {
             command.arg("-NoBattlEye");
         }
 
+        // when specified, this will overwrite MaxPlayers in the GUS
+        // if it is neither specified on command line nor set in the GUS it is set to 70
+        if let Some(max_players) = self.max_players {
+            command.arg(format!(r"-WinLiveMaxPlayers={max_players}"));
+        } else if let Some(max_players) = game_user_settings.max_players() {
+            command.arg(format!(r"-WinLiveMaxPlayers={max_players}"));
+        }
+
         if let Some(mods) = game_user_settings.active_mods() {
             command.arg(format!(r"-mods={mods}"));
         }
@@ -85,12 +93,6 @@ impl Args {
 
         attributes.push(format!("Port={}", self.port));
         attributes.push(format!("QueryPort={}", self.query_port));
-
-        if let Some(max_players) = self.max_players {
-            attributes.push(format!("{MAX_PLAYERS}={max_players}"));
-        } else if let Some(max_players) = game_user_settings.max_players() {
-            attributes.push(format!("{MAX_PLAYERS}={max_players}"));
-        }
 
         attributes.extend_from_slice(&self.attributes);
 


### PR DESCRIPTION
The map-based parameter MaxPlayers is now a server based parameter in ASA.
i have toyed with the idea of removing the GameEngine parsing entirely because of that but i ultimately decided against it, because a user might have the setting in the config, expecting it to work, which is why i opted to prioritize it over the command line option, YMMV.

caveat: im no rust dev (or any dev for that matter) i just try to make things work, sometimes poorly :)

Tested (on linux only):
MaxPlayers=10 in GUS, no --max-players -> 10
MaxPlayers=10 in GUS, --max-players=15 -> 15
MaxPlayers=15 in GUS, --max-players=15 -> 15
no MaxPlayers in GUS, --max-players=15 -> 15
nothing -> 70

Thanks!